### PR TITLE
fix openshift doc usage

### DIFF
--- a/charts/pacman/Chart.yaml
+++ b/charts/pacman/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 0.1.7
-appVersion: "0.1.7"
+version: 0.1.8
+appVersion: "0.1.8"
 name: pacman
 description: Pac-Man Demo App for Kubernetes
 home: https://github.com/shuguet/pacman

--- a/charts/pacman/README.md
+++ b/charts/pacman/README.md
@@ -28,10 +28,14 @@ helm install pacman pacman/pacman -n pacman --create-namespace \
     --set service.type=LoadBalancer
 ```
 
-Route (Requires an OpenShift installation. Adapt the class/host to your environment):
+For Openshift use a route and remove the security context otherwise the 
+mongodb securityContext will be created with the user 1001 which is not allowed 
+by default in Openshift.
 ```
 helm install pacman pacman/pacman -n pacman --create-namespace \
-    --set route.create=true
+    --set route.create= \
+    --set mongodb.containerSecurityContext.enabled=false \
+    --set mongodb.podSecurityContext.enabled=false
 ```
 
 ## Other installation options:


### PR DESCRIPTION
For Openshift use a route and remove the security context otherwise the mongodb securityContext will be created with the user 1001 which is not allowed by default in Openshift unless you have a the anyuid scc applied to the sa running mongodb, a situation we want to avoid.

Openshift will add himself the security context at a high range at pod admission.