### PR TITLE
npm cache folder issue on ocp

### DIFF
--- a/charts/pacman/Chart.yaml
+++ b/charts/pacman/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 0.1.9
-appVersion: "0.1.9"
+version: 0.1.10
+appVersion: "0.1.10"
 name: pacman
 description: Pac-Man Demo App for Kubernetes
 home: https://github.com/shuguet/pacman
@@ -16,6 +16,8 @@ maintainers:
     url: https://vzilla.co.uk/
   - name: Sylvain Huguet
     url: https://www.huguet.me
+  - name: Michael Courcy
+    url: https://github.com/michaelcourcy
 
 dependencies:
 - name: mongodb

--- a/charts/pacman/templates/pacman-deployment.yaml
+++ b/charts/pacman/templates/pacman-deployment.yaml
@@ -22,8 +22,14 @@ spec:
         {{- include "pacman.selectorLabels" . | nindent 8 }}
         name: pacman
     spec:
+      volumes:
+      - name: npm-cache-volume
+        emptyDir: {}
       containers:
         - name: {{ .Chart.Name }}
+          volumeMounts:
+           - mountPath: /.npm
+             name: npm-cache-volume
           # image: "ghcr.io/shuguet/pacman:master"
           image: {{ default .Chart.AppVersion .Values.pacman.image.tag | print .Values.pacman.image.registry "/" .Values.pacman.image.repository "/" .Values.pacman.image.image ":"  }}
           imagePullPolicy: {{ .Values.pacman.image.pullPolicy }}


### PR DESCRIPTION
When running the pacman image on ocp we get this issue 

```
k logs pacman-555d9f6f5-9fk8l

> pacman@0.0.1 start
> node .

npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /.npm
npm ERR! errno -13
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1001190000:0 "/.npm"
```

To avoid this problem we make sure that /.npm is mounted as an empty dir and ocp through the automatic use of fsGroup will give appropriate authorization to the mount point.