### PR TITLE
Fix CodeQL Analysis workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@956f09c2ef1926b580554b9014cfb8a51abf89dd # v2.16.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@956f09c2ef1926b580554b9014cfb8a51abf89dd # v2.16.6


### PR DESCRIPTION
CodeQL GitHub Action is currently using deprecated versions of the actions.
Bumped up the version number of the action to the most recent.